### PR TITLE
Add controller renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,24 +2,24 @@
 
 Webpacker-React makes it easy to use [React](https://facebook.github.io/react/) with [Webpacker](https://github.com/rails/webpacker) in your Rails applications.
 
-Important note : Webpacker is not yet officially released. It will be included in Rails 5.1 but is highly experimental for now.
+Important note: Webpacker is not yet officially released. It will be included in Rails 5.1 but is highly experimental for now.
 
-An example application is available : https://github.com/renchap/webpacker-react-example/
+An example application is available: https://github.com/renchap/webpacker-react-example/
 
-This gem is a work in progress. Final feature list :
+This gem is a work in progress. Final feature list:
 
 - [x] uses the new Webpacker way of integrating Javascript with Rails (using packs)
 - [x] render React components from views using a `react_component` helper
-- [ ] render React components from controllers using `render react_component: 'name'`
+- [x] render React components from controllers using `render react_component: 'name'`
 - [ ] render components server-side
 - [ ] support for [hot reloading](https://github.com/gaearon/react-hot-loader)
 - [ ] use a Rails generator to create new components
 
 ## Installation
 
-Your Rails application needs to use Webpacker and have the React integration done. Please refer to their documentation to the webpacker documentation for this : https://github.com/rails/webpacker/blob/master/README.md#ready-for-react
+Your Rails application needs to use Webpacker and have the React integration done. Please refer to their documentation documentation for this: https://github.com/rails/webpacker/blob/master/README.md#ready-for-react
 
-First, you need to add the webpacker-react gem to your Rails app Gemfile :
+First, you need to add the webpacker-react gem to your Rails app Gemfile:
 
 ```ruby
 gem 'webpacker-react', github: 'renchap/webpacker-react'
@@ -27,7 +27,7 @@ gem 'webpacker-react', github: 'renchap/webpacker-react'
 
 Once done, run `bundler` to install the gem.
 
-Then you need to update your `vendor/package.json` file to include the `webpacker-react` NPM module :
+Then you need to update your `vendor/package.json` file to include the `webpacker-react` NPM module:
 ```json
   "dependencies": {
     "..."
@@ -39,12 +39,12 @@ Finally, run `./bin/yarn` to install the module. You are now all set!
 
 ### Note about versions
 
-Webpacker-React contains two parts : a Javascript module and a Ruby gem. Both of those components respect [semantic versioning](http://semver.org). **When upgrading the gem, you need to upgrade the NPM module to the same minor version**. New patch versions can be released for each of the two independently, so it is ok to have the NPM module at version `A.X.Y` and the gem at version `A.X.Z`, but you should never have a different `A` or `X`.
+Webpacker-React contains two parts: a Javascript module and a Ruby gem. Both of those components respect [semantic versioning](http://semver.org). **When upgrading the gem, you need to upgrade the NPM module to the same minor version**. New patch versions can be released for each of the two independently, so it is ok to have the NPM module at version `A.X.Y` and the gem at version `A.X.Z`, but you should never have a different `A` or `X`.
 
 ## Usage
 
 The first step is to register your root components (those you want to load from your HTML).
-In your pack file (`app/javascript/packs/*.js`), import your components as well as `webpacker-react` and register them. Considering you have a component in `app/javascript/components/hello.js` :
+In your pack file (`app/javascript/packs/*.js`), import your components as well as `webpacker-react` and register them. Considering you have a component in `app/javascript/components/hello.js`:
 
 ```javascript
 import Hello from 'components/hello';
@@ -53,25 +53,41 @@ import WebpackerReact from 'webpacker-react';
 WebpackerReact.register(Hello);
 ```
 
-Now you can use the `react_component` helper in your views to render your React component :
+Now you can render React components from your views or your controllers.
+
+### Rendering from a view
+
+Use the `react_component` helper:
 
 ```erb
 <%= react_component('Hello', name: 'React') %>
 ```
 
-Note: you need to have [Webpack process your code](https://github.com/rails/webpacker#binstubs) before it is available to the browser, either by manually running `./bin/webpack` or having the `./bin/webpack-watcher` process running.
+### Rendering from a controller
+
+```rb
+class PageController < ApplicationController
+  def main
+    render react_component: 'Hello', props: { name: 'React' }
+  end
+end
+```
+
+You can pass any of the usual arguments to render in this call: `layout`, `status`, `content_type`, etc.
+
+*Note: you need to have [Webpack process your code](https://github.com/rails/webpacker#binstubs) before it is available to the browser, either by manually running `./bin/webpack` or having the `./bin/webpack-watcher` process running.*
 
 ## Development
 
 To work on this gem locally, you first need to clone and setup the example application.
 
-Then you need to change the example app Gemfile to point to your local repository and run bundle afterwise :
+Then you need to change the example app Gemfile to point to your local repository and run bundle afterwise:
 
 ```ruby
 gem 'webpacker-react', path: '~/code/webpacker-react/'
 ```
 
-Finally, you need to tell Yarn to use your local copy of the NPM module in this application, using [`yarn link`](https://yarnpkg.com/en/docs/cli/link) :
+Finally, you need to tell Yarn to use your local copy of the NPM module in this application, using [`yarn link`](https://yarnpkg.com/en/docs/cli/link):
 
 ```
 $ cd ~/code/webpacker-react/javascript/webpacker_react-npm-module/

--- a/javascript/webpacker_react-npm-module/index.js
+++ b/javascript/webpacker_react-npm-module/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 
-window.WebpackerReact = {
+var WebpackerReact = {
   eventsRegistered: false,
   registeredComponents : {},
 
@@ -50,6 +50,6 @@ window.WebpackerReact = {
   }
 };
 
-window.WebpackerReact.addEventEventhandlers();
+WebpackerReact.addEventEventhandlers();
 
-module.exports = window.WebpackerReact;
+export default WebpackerReact;

--- a/lib/webpacker/react.rb
+++ b/lib/webpacker/react.rb
@@ -5,4 +5,6 @@ module Webpacker
   end
 end
 
-require 'webpacker/react/railtie' if defined?(Rails)
+require "webpacker/react/railtie" if defined?(Rails)
+require "webpacker/react/helpers"
+require "webpacker/react/component"

--- a/lib/webpacker/react/component.rb
+++ b/lib/webpacker/react/component.rb
@@ -1,0 +1,19 @@
+module Webpacker
+  module React
+    class Component
+      include ActionView::Helpers::TagHelper
+      include ActionView::Helpers::TextHelper
+
+      attr_accessor :name
+
+      def initialize(name)
+        @name = name
+      end
+
+      def render(props = {}, options = {})
+        data = { data: { 'react-class' => @name, 'react-props' => props.to_json } }
+        tag('div', options.deep_merge(data))
+      end
+    end
+  end
+end

--- a/lib/webpacker/react/helpers.rb
+++ b/lib/webpacker/react/helpers.rb
@@ -1,8 +1,8 @@
 module Webpacker
   module React
     module Helpers
-      def react_component(class_name, props = {}, &block)
-        tag('div', data: { 'react-class' => class_name, 'react-props' => props.to_json })
+      def react_component(component_name, props = {}, options = {})
+        Webpacker::React::Component.new(component_name).render(props, options)
       end
     end
   end

--- a/lib/webpacker/react/railtie.rb
+++ b/lib/webpacker/react/railtie.rb
@@ -1,10 +1,22 @@
-require 'rails/railtie'
-require 'webpacker/react/helpers'
+require "rails/railtie"
 
-class Webpacker::React::Engine < ::Rails::Engine
-  initializer :webpacker_react do
-    ActiveSupport.on_load(:action_controller) do
-      ActionController::Base.helper ::Webpacker::React::Helpers
+module Webpacker
+  module React
+    class Engine < ::Rails::Engine
+      initializer :webpacker_react do
+        ActiveSupport.on_load(:action_controller) do
+          ActionController::Base.helper ::Webpacker::React::Helpers
+        end
+      end
+
+      initializer :webpacker_react_renderer, group: :all do |app|
+        ActionController::Renderers.add :react_component do |component_name, options|
+          props = options.fetch(:props, {})
+          html = Webpacker::React::Component.new(component_name).render(props)
+          render_options = options.merge(inline: html)
+          render(render_options)
+        end
+      end
     end
   end
 end

--- a/test/rails_helper.rb
+++ b/test/rails_helper.rb
@@ -1,0 +1,4 @@
+require "rails"
+require "rails/all"
+require "action_view/testing/resolvers"
+require "rails/test_help"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-require 'webpacker/react'
+$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 
-require 'minitest/autorun'
+require "rails_helper"
+require "webpacker/react"
+require "minitest/autorun"

--- a/test/webpacker/react/component_test.rb
+++ b/test/webpacker/react/component_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+module Webpacker
+  module React
+    class ComponentTest < Minitest::Test
+      include ERB::Util
+
+      def setup
+        @component = {
+          name: "Hello",
+          props: {
+            name: "React"
+          }
+        }
+      end
+
+      def test_it_outputs_a_div_element
+        expected_html = "<div data-react-class=\"#{@component[:name]}\" data-react-props=\"#{escaped_props(@component[:props])}\" />"
+        html = Webpacker::React::Component.new(@component[:name])
+                                          .render(@component[:props])
+
+        assert_equal html, expected_html
+      end
+
+      def test_it_accepts_html_options
+        html = Webpacker::React::Component.new(@component[:name])
+                                          .render(@component[:props], class: "class", id: "id")
+
+       assert(html.include?('class="class"') && html.include?('id="id"'), "it includes HTML options")
+      end
+
+      private
+
+      def escaped_props(props)
+        html_escape(json_escape(props.to_json))
+      end
+    end
+  end
+end

--- a/test/webpacker/react_test.rb
+++ b/test/webpacker/react_test.rb
@@ -1,11 +1,9 @@
 require 'test_helper'
 
-class Webpacker::ReactTest < Minitest::Test
-  def test_that_it_has_a_version_number
-    refute_nil ::Webpacker::React::VERSION
-  end
-
-  def test_it_does_something_useful
-    assert false
+module Webpacker
+  class ReactTest < Minitest::Test
+    def test_that_it_has_a_version_number
+      refute_nil ::Webpacker::React::VERSION
+    end
   end
 end

--- a/webpacker-react.gemspec
+++ b/webpacker-react.gemspec
@@ -29,11 +29,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 1.9.3'
+  spec.required_ruby_version = ">= 1.9.3"
 
-  spec.add_dependency 'webpacker'
+  spec.add_dependency "webpacker"
 
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "rails", "~> 5.0"
 end


### PR DESCRIPTION
Adds a controller renderer for react components.

Had to change the syntax of the npm module a bit, because it was giving me trouble (presumably related to this: https://github.com/webpack/webpack/issues/4039)

