### PR TITLE
Fix html output of Webpacker::React::Component#render 

### DIFF
--- a/lib/webpacker/react/component.rb
+++ b/lib/webpacker/react/component.rb
@@ -12,7 +12,7 @@ module Webpacker
 
       def render(props = {}, options = {})
         data = { data: { 'react-class' => @name, 'react-props' => props.to_json } }
-        tag('div', options.deep_merge(data))
+        content_tag(:div, '', options.deep_merge(data))
       end
     end
   end

--- a/test/webpacker/react/component_test.rb
+++ b/test/webpacker/react/component_test.rb
@@ -15,11 +15,24 @@ module Webpacker
       end
 
       def test_it_outputs_a_div_element
-        expected_html = "<div data-react-class=\"#{@component[:name]}\" data-react-props=\"#{escaped_props(@component[:props])}\" />"
+        expected_html = "<div data-react-class=\"#{@component[:name]}\" data-react-props=\"#{escaped_props(@component[:props])}\"></div>"
         html = Webpacker::React::Component.new(@component[:name])
                                           .render(@component[:props])
 
-        assert_equal html, expected_html
+        assert_equal expected_html, html
+      end
+
+      def test_it_outputs_div_elements_in_series
+        expected_html = "<div data-react-class=\"#{@component[:name]}\" data-react-props=\"#{escaped_props(@component[:props])}\"></div>"
+        expected_html += "<div data-react-class=\"#{@component[:name]}\" data-react-props=\"#{escaped_props(@component[:props])}\"></div>"
+
+        html = Webpacker::React::Component.new(@component[:name])
+                                          .render(@component[:props])
+
+        html += Webpacker::React::Component.new(@component[:name])
+                                          .render(@component[:props])
+
+        assert_equal expected_html, html
       end
 
       def test_it_accepts_html_options


### PR DESCRIPTION

Currently, calling the view helper multiple times will nest HTML output. The `render` method currently returns a self-closing `div` (`<div />)` element.  This PR changes the returned HTML to a `div` with an opening and closing tag (`<div></div>`).

_view_component.html.erb_

```erb
<%= react_component('Hello', key: '1', name: 'a component rendered from a view') %>
<%= react_component('Hello', key: '2', name: 'a component rendered from a view') %>
<%= react_component('Hello', key: '3', name: 'a component rendered from a view') %>
```


## Before

Resulting HTML before call to `React.DOM.render`:

_view_component.html_
```html
<body>
  <div data-react-class="Hello" data-react-props="{&quot;key&quot;:&quot;1&quot;,&quot;name&quot;:&quot;a component rendered from a view&quot;}">
    <div data-react-class="Hello" data-react-props="{&quot;key&quot;:&quot;2&quot;,&quot;name&quot;:&quot;a component rendered from a view&quot;}">
      <div data-react-class="Hello" data-react-props="{&quot;key&quot;:&quot;3&quot;,&quot;name&quot;:&quot;a component rendered from a view&quot;}">
      </div>
    </div>
  </div>
</body>
```

## After

Resulting HTML before call to `React.DOM.render`:

_view_component.html_
```html
<body>
  <div data-react-class="Hello" data-react-props="{&quot;key&quot;:&quot;1&quot;,&quot;name&quot;:&quot;a component rendered from a view&quot;}"></div>
  <div data-react-class="Hello" data-react-props="{&quot;key&quot;:&quot;2&quot;,&quot;name&quot;:&quot;a component rendered from a view&quot;}"></div>
  <div data-react-class="Hello" data-react-props="{&quot;key&quot;:&quot;3&quot;,&quot;name&quot;:&quot;a component rendered from a view&quot;}"></div>
</body>
```

This changes uses `contet_tag` instead of `tag` to generate HTML, similar to [react-rails ComponentMount#react_component](https://github.com/reactjs/react-rails/blob/v1.10.0/lib/react/rails/component_mount.rb#L48).

I'm using Chrome.  Maybe other browsers render self-closing tags appropriately, but hopefully this change does not affect support for other browsers.


Fixes #8 