### PR TITLE
Support component mounting and unmounting in Turbolinks and PJAX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-
+## 0.2.0 - in progress
+### Added
+- support for Turbolinks5, Turbolinks 2.4 and PJAX. Components will be mounted and unmounted when Turbolinks-specific events occur. Also, the integration works with Turbolinks 5 cache.
+- Now, Webpacker::React *always* requires an explicit initialization via `WebpackerReact.initialize()`, which must be done after the Turbolinks initialization, if the Turbolinks library is used.
 ## 0.1.0 - 2017-02-23
 ### Added
 - First released version

--- a/README.md
+++ b/README.md
@@ -51,7 +51,33 @@ import Hello from 'components/hello'
 import WebpackerReact from 'webpacker-react'
 
 WebpackerReact.register(Hello)
+WebpackerReact.initialize()
 ```
+
+### With Turbolinks
+
+You have to make sure Turbolinks is loaded before calling `WebpackerReact.initialize()`.
+
+For example:
+
+```javascript
+import Hello from 'components/hello'
+import WebpackerReact from 'webpacker-react'
+import Turbolinks from 'turbolinks'
+
+Turbolinks.start()
+WebpackerReact.initialize()
+
+WebpackerReact.register(Hello)
+```
+
+You may also load turbolinks in regular asset pipeline `application.js`:
+
+```javascript
+//= require "turbolinks"
+```
+
+In that case, make sure your packs are loaded *after* `application.js`
 
 Now you can render React components from your views or your controllers.
 

--- a/javascript/webpacker_react-npm-module/package.json
+++ b/javascript/webpacker_react-npm-module/package.json
@@ -7,7 +7,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",
-    "babel-preset-es2015": "^6.18.0",
+    "babel-preset-es2015": "^6.22.0",
     "eslint": "^3.16.1",
     "eslint-config-airbnb": "^14.1.0",
     "eslint-plugin-import": "^2.2.0",

--- a/javascript/webpacker_react-npm-module/src/index.js
+++ b/javascript/webpacker_react-npm-module/src/index.js
@@ -42,8 +42,8 @@ const WebpackerReact = {
     this.wrapForHMR = wrapForHMR
   },
 
-  register(component, options) {
-    const name = component.name || (options !== undefined && options.as)
+  register(component) {
+    const name = component.name
 
     if (!name) {
       console.error("Could not determine component name. Probably it's a functional component. " +
@@ -63,7 +63,7 @@ const WebpackerReact = {
 
   mountComponents() {
     const registeredComponents = this.registeredComponents
-    const toMount = document.querySelectorAll(`[${CLASS_ATTRIBUTE_NAME}]`)
+    const toMount = document.querySelectorAll(`[${CLASS_ATTRIBUTE_NAME}]`) || []
 
     toMount.forEach((node) => {
       const className = node.getAttribute(CLASS_ATTRIBUTE_NAME)
@@ -78,7 +78,7 @@ const WebpackerReact = {
   },
 
   unmountComponents() {
-    const mounted = document.querySelectorAll(`[${CLASS_ATTRIBUTE_NAME}]`)
+    const mounted = document.querySelectorAll(`[${CLASS_ATTRIBUTE_NAME}]`) || []
     mounted.forEach(node => ReactDOM.unmountComponentAtNode(node))
   },
 

--- a/javascript/webpacker_react-npm-module/src/index.js
+++ b/javascript/webpacker_react-npm-module/src/index.js
@@ -85,9 +85,9 @@ const WebpackerReact = {
     }
   },
 
-  addEventEventhandlers() {
+  initialize() {
     if (this.eventsRegistered === true) {
-      console.warn('webpacker-react: events have already been registered')
+      console.warn('webpacker-react: events have already been initialized')
       return false
     }
 
@@ -97,7 +97,5 @@ const WebpackerReact = {
     return true
   }
 }
-
-WebpackerReact.addEventEventhandlers()
 
 export default WebpackerReact

--- a/javascript/webpacker_react-npm-module/src/index.js
+++ b/javascript/webpacker_react-npm-module/src/index.js
@@ -120,8 +120,16 @@ const WebpackerReact = {
     this.wrapForHMR = wrapForHMR
   },
 
-  register(component) {
-    const name = component.name
+  register(component, options) {
+    var name = component.name || (options !== undefined && options.as);
+
+    console.log("Registering component: " + name)
+
+    if (!name) {
+      throw "Could not determine component name. Probably it's a functional component. " +
+      "Please declare component name by passing an 'as' parameter: " +
+      "register(Component,  {as: 'Component'})"
+    }
 
     if (this.registeredComponents[name]) {
       console.warn(`webpacker-react: Cant register component, another one with this name is already registered: ${name}`)

--- a/javascript/webpacker_react-npm-module/src/index.js
+++ b/javascript/webpacker_react-npm-module/src/index.js
@@ -45,8 +45,6 @@ const WebpackerReact = {
   register(component, options) {
     var name = component.name || (options !== undefined && options.as);
 
-    console.log("Registering component: " + name)
-
     if (!name) {
       throw "Could not determine component name. Probably it's a functional component. " +
       "Please declare component name by passing an 'as' parameter: " +
@@ -63,8 +61,6 @@ const WebpackerReact = {
   },
 
   mountComponents() {
-    console.debug("Mounting components")
-
     var registeredComponents = this.registeredComponents
     var toMount = document.querySelectorAll('[' + CLASS_ATTRIBUTE_NAME + ']')
 
@@ -82,13 +78,10 @@ const WebpackerReact = {
   },
 
   unmountComponents() {
-    console.debug("Unmounting components")
-
     var mounted = document.querySelectorAll('[' + CLASS_ATTRIBUTE_NAME + ']')
 
     for (var i = 0; i < mounted.length; ++i) {
       var node = mounted[i];
-      console.log(node);
       ReactDOM.unmountComponentAtNode(node);
     }
   },

--- a/javascript/webpacker_react-npm-module/src/index.js
+++ b/javascript/webpacker_react-npm-module/src/index.js
@@ -9,9 +9,88 @@ const WebpackerReact = {
   registeredComponents: {},
   wrapForHMR: null,
 
-  render(node, component) {
-    const propsJson = node.getAttribute(PROPS_ATTRIBUTE_NAME)
-    const props = propsJson && JSON.parse(propsJson)
+  ujs: {
+    handleEvent(eventName, callback) {
+      // jQuery is optional. Use it to support legacy browsers.
+      var $ = (typeof window.jQuery !== 'undefined') && window.jQuery;
+
+      if ($) {
+        $(document).on(eventName, callback);
+      } else {
+        document.addEventListener(eventName, callback);
+      }
+    },
+
+    setup: function (onMount, onUnmount) {
+      var $ = (typeof window.jQuery !== 'undefined') && window.jQuery;
+      // Detect which kind of events to set up:
+      if (typeof Turbolinks !== 'undefined' && Turbolinks.supported) {
+        if (typeof Turbolinks.EVENTS !== 'undefined') {
+          // Turbolinks.EVENTS is in classic version 2.4.0+
+          this.turbolinksClassic(onMount, onUnmount);
+        } else if (typeof Turbolinks.controller !== "undefined") {
+          // Turbolinks.controller is in version 5+
+          this.turbolinks5(onMount, onUnmount);
+        } else {
+          // ReactRailsUJS.TurbolinksClassicDeprecated.setup();
+          this.turbolinksClassicDeprecated(onMount, onUnmount);
+        }
+      } else if ($ && typeof $.pjax === 'function') {
+        this.pjax(onMount, onUnmount);
+      } else {
+        this.native(onMount);
+      }
+    },
+
+    turbolinks5: function (onMount, onUnmount) {
+      this.handleEvent('turbolinks:load', onMount);
+      this.handleEvent('turbolinks:before-render', onUnmount);
+    },
+
+    turbolinksClassic: function (onMount, onUnmount) {
+      this.handleEvent(Turbolinks.EVENTS.CHANGE, onMount);
+      this.handleEvent(Turbolinks.EVENTS.BEFORE_UNLOAD, onUnmount);
+    },
+
+    turbolinksClassicDeprecated: function (onMount, onUnmount) {
+      // Before Turbolinks 2.4.0, Turbolinks didn't
+      // have named events and didn't have a before-unload event.
+      // Also, it didn't work with the Turbolinks cache, see
+      // https://github.com/reactjs/react-rails/issues/87
+      Turbolinks.pagesCached(0);
+      this.handleEvent('page:change', onMount);
+      this.handleEvent('page:receive', onUnmount);
+    },
+
+    pjax: function (onMount, onUnmount) {
+      this.handleEvent('ready', onMount);
+      this.handleEvent('pjax:end', onMount);
+      this.handleEvent('pjax:beforeReplace', onUnmount);
+    },
+
+    native: function (onMount) {
+      var $ = (typeof window.jQuery !== 'undefined') && window.jQuery;
+
+      if ($) {
+        $(function () {
+          onMount()
+        });
+      } else if ('addEventListener' in window) {
+        document.addEventListener('DOMContentLoaded', function () {
+          onMount()
+        });
+      } else {
+        // add support to IE8 without jQuery
+        window.attachEvent('onload', function () {
+          onMount()
+        });
+      }
+    }
+  },
+
+  render: function (node, component) {
+    var propsJson = node.getAttribute(PROPS_ATTRIBUTE_NAME)
+    var props = propsJson && JSON.parse(propsJson)
 
     let reactElement = React.createElement(component, props)
     if (this.wrapForHMR) {
@@ -22,6 +101,7 @@ const WebpackerReact = {
 
   renderOnHMR(component) {
     const name = component.name
+
     this.registeredComponents[name] = component
 
     if (!this.wrapForHMR) {
@@ -52,29 +132,40 @@ const WebpackerReact = {
     return true
   },
 
-  addEventEventhandlers() {
-    const registeredComponents = this.registeredComponents
+  mountComponents() {
+    var registeredComponents = this.registeredComponents
+    var toMount = document.querySelectorAll('[' + CLASS_ATTRIBUTE_NAME + ']')
 
-    if (this.eventsRegistered === true) {
-      console.warn('webpacker-react: events have already been registered')
+    for (var i = 0; i < toMount.length; ++i) {
+      var node = toMount[i]
+      var className = node.getAttribute(CLASS_ATTRIBUTE_NAME)
+      var component = registeredComponents[className]
+
+      if (component) {
+        this.render(node, component)
+      } else {
+        console.error('webpacker-react: cant render a component that has not been registered: ' + className)
+      }
+    }
+  },
+
+  unmountComponents() {
+    var mounted = document.querySelectorAll('[' + CLASS_ATTRIBUTE_NAME + ']')
+
+    for (var i = 0; i < mounted.length; ++i) {
+      var node = mounted[i]
+
+      ReactDOM.unmountComponentAtNode(node);
+    }
+  },
+
+  addEventEventhandlers() {
+    if (this.eventsRegistered == true) {
+      console.warn("webpacker-react: events have already been registered")
       return false
     }
 
-    document.addEventListener('DOMContentLoaded', () => {
-      const toMount = document.querySelectorAll(`[${CLASS_ATTRIBUTE_NAME}]`)
-
-      for (let i = 0; i < toMount.length; i += 1) {
-        const node = toMount[i]
-        const className = node.getAttribute(CLASS_ATTRIBUTE_NAME)
-        const component = registeredComponents[className]
-
-        if (component) {
-          this.render(node, component)
-        } else {
-          console.error(`webpacker-react: cant render a component that has not been registered: ${className}`)
-        }
-      }
-    })
+    this.ujs.setup(this.mountComponents.bind(this), this.unmountComponents.bind(this));
 
     this.eventsRegistered = true
     return true

--- a/javascript/webpacker_react-npm-module/src/index.js
+++ b/javascript/webpacker_react-npm-module/src/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import ujs from './ujs';
+import ujs from './ujs'
 
 const CLASS_ATTRIBUTE_NAME = 'data-react-class'
 const PROPS_ATTRIBUTE_NAME = 'data-react-props'
@@ -10,15 +10,15 @@ const WebpackerReact = {
   registeredComponents: {},
   wrapForHMR: null,
 
-  render: function (node, component) {
-      var propsJson = node.getAttribute(PROPS_ATTRIBUTE_NAME)
-      var props = propsJson && JSON.parse(propsJson)
+  render(node, component) {
+    const propsJson = node.getAttribute(PROPS_ATTRIBUTE_NAME)
+    const props = propsJson && JSON.parse(propsJson)
 
-      let reactElement = React.createElement(component, props)
-      if (this.wrapForHMR) {
-        reactElement = this.wrapForHMR(reactElement)
-      }
-      ReactDOM.render(reactElement, node)
+    let reactElement = React.createElement(component, props)
+    if (this.wrapForHMR) {
+      reactElement = this.wrapForHMR(reactElement)
+    }
+    ReactDOM.render(reactElement, node)
   },
 
   renderOnHMR(component) {
@@ -43,7 +43,7 @@ const WebpackerReact = {
   },
 
   register(component, options) {
-    var name = component.name || (options !== undefined && options.as);
+    const name = component.name || (options !== undefined && options.as)
 
     if (!name) {
       throw "Could not determine component name. Probably it's a functional component. " +
@@ -61,44 +61,39 @@ const WebpackerReact = {
   },
 
   mountComponents() {
-    var registeredComponents = this.registeredComponents
-    var toMount = document.querySelectorAll('[' + CLASS_ATTRIBUTE_NAME + ']')
+    const registeredComponents = this.registeredComponents
+    const toMount = document.querySelectorAll(`[${CLASS_ATTRIBUTE_NAME}]`)
 
-    for (var i = 0; i < toMount.length; ++i) {
-      var node = toMount[i]
-      var className = node.getAttribute(CLASS_ATTRIBUTE_NAME)
-      var component = registeredComponents[className]
+    toMount.forEach((node) => {
+      const className = node.getAttribute(CLASS_ATTRIBUTE_NAME)
+      const component = registeredComponents[className]
 
       if (component) {
         this.render(node, component)
       } else {
-        console.error('webpacker-react: cant render a component that has not been registered: ' + className)
+        console.error(`webpacker-react: cant render a component that has not been registered: ${className}`)
       }
-    }
+    })
   },
 
   unmountComponents() {
-    var mounted = document.querySelectorAll('[' + CLASS_ATTRIBUTE_NAME + ']')
-
-    for (var i = 0; i < mounted.length; ++i) {
-      var node = mounted[i];
-      ReactDOM.unmountComponentAtNode(node);
-    }
+    const mounted = document.querySelectorAll(`[${CLASS_ATTRIBUTE_NAME}]`)
+    mounted.forEach(node => ReactDOM.unmountComponentAtNode(node))
   },
 
   addEventEventhandlers() {
-    if (this.eventsRegistered == true) {
-      console.warn("webpacker-react: events have already been registered");
-      return false;
+    if (this.eventsRegistered === true) {
+      console.warn('webpacker-react: events have already been registered')
+      return false
     }
 
-    ujs.setup(this.mountComponents.bind(this), this.unmountComponents.bind(this));
+    ujs.setup(this.mountComponents.bind(this), this.unmountComponents.bind(this))
 
-    this.eventsRegistered = true;
-    return true;
+    this.eventsRegistered = true
+    return true
   }
 }
 
-WebpackerReact.addEventEventhandlers();
+WebpackerReact.addEventEventhandlers()
 
 export default WebpackerReact

--- a/javascript/webpacker_react-npm-module/src/index.js
+++ b/javascript/webpacker_react-npm-module/src/index.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
+import ujs from './ujs';
 
 const CLASS_ATTRIBUTE_NAME = 'data-react-class'
 const PROPS_ATTRIBUTE_NAME = 'data-react-props'
@@ -8,85 +9,6 @@ const WebpackerReact = {
   eventsRegistered: false,
   registeredComponents: {},
   wrapForHMR: null,
-
-  ujs: {
-    handleEvent(eventName, callback) {
-      // jQuery is optional. Use it to support legacy browsers.
-      var $ = (typeof window.jQuery !== 'undefined') && window.jQuery;
-
-      if ($) {
-        $(document).on(eventName, callback);
-      } else {
-        document.addEventListener(eventName, callback);
-      }
-    },
-
-    setup: function (onMount, onUnmount) {
-      var $ = (typeof window.jQuery !== 'undefined') && window.jQuery;
-      // Detect which kind of events to set up:
-      if (typeof Turbolinks !== 'undefined' && Turbolinks.supported) {
-        if (typeof Turbolinks.EVENTS !== 'undefined') {
-          // Turbolinks.EVENTS is in classic version 2.4.0+
-          this.turbolinksClassic(onMount, onUnmount);
-        } else if (typeof Turbolinks.controller !== "undefined") {
-          // Turbolinks.controller is in version 5+
-          this.turbolinks5(onMount, onUnmount);
-        } else {
-          // ReactRailsUJS.TurbolinksClassicDeprecated.setup();
-          this.turbolinksClassicDeprecated(onMount, onUnmount);
-        }
-      } else if ($ && typeof $.pjax === 'function') {
-        this.pjax(onMount, onUnmount);
-      } else {
-        this.native(onMount);
-      }
-    },
-
-    turbolinks5: function (onMount, onUnmount) {
-      this.handleEvent('turbolinks:load', onMount);
-      this.handleEvent('turbolinks:before-render', onUnmount);
-    },
-
-    turbolinksClassic: function (onMount, onUnmount) {
-      this.handleEvent(Turbolinks.EVENTS.CHANGE, onMount);
-      this.handleEvent(Turbolinks.EVENTS.BEFORE_UNLOAD, onUnmount);
-    },
-
-    turbolinksClassicDeprecated: function (onMount, onUnmount) {
-      // Before Turbolinks 2.4.0, Turbolinks didn't
-      // have named events and didn't have a before-unload event.
-      // Also, it didn't work with the Turbolinks cache, see
-      // https://github.com/reactjs/react-rails/issues/87
-      Turbolinks.pagesCached(0);
-      this.handleEvent('page:change', onMount);
-      this.handleEvent('page:receive', onUnmount);
-    },
-
-    pjax: function (onMount, onUnmount) {
-      this.handleEvent('ready', onMount);
-      this.handleEvent('pjax:end', onMount);
-      this.handleEvent('pjax:beforeReplace', onUnmount);
-    },
-
-    native: function (onMount) {
-      var $ = (typeof window.jQuery !== 'undefined') && window.jQuery;
-
-      if ($) {
-        $(function () {
-          onMount()
-        });
-      } else if ('addEventListener' in window) {
-        document.addEventListener('DOMContentLoaded', function () {
-          onMount()
-        });
-      } else {
-        // add support to IE8 without jQuery
-        window.attachEvent('onload', function () {
-          onMount()
-        });
-      }
-    }
-  },
 
   render: function (node, component) {
     var propsJson = node.getAttribute(PROPS_ATTRIBUTE_NAME)
@@ -161,25 +83,24 @@ const WebpackerReact = {
     var mounted = document.querySelectorAll('[' + CLASS_ATTRIBUTE_NAME + ']')
 
     for (var i = 0; i < mounted.length; ++i) {
-      var node = mounted[i]
-
+      var node = mounted[i];
       ReactDOM.unmountComponentAtNode(node);
     }
   },
 
   addEventEventhandlers() {
     if (this.eventsRegistered == true) {
-      console.warn("webpacker-react: events have already been registered")
-      return false
+      console.warn("webpacker-react: events have already been registered");
+      return false;
     }
 
-    this.ujs.setup(this.mountComponents.bind(this), this.unmountComponents.bind(this));
+    ujs.setup(this.mountComponents.bind(this), this.unmountComponents.bind(this));
 
-    this.eventsRegistered = true
-    return true
+    this.eventsRegistered = true;
+    return true;
   }
 }
 
-WebpackerReact.addEventEventhandlers()
+WebpackerReact.addEventEventhandlers();
 
 export default WebpackerReact

--- a/javascript/webpacker_react-npm-module/src/index.js
+++ b/javascript/webpacker_react-npm-module/src/index.js
@@ -63,7 +63,7 @@ const WebpackerReact = {
 
   mountComponents() {
     const registeredComponents = this.registeredComponents
-    const toMount = document.querySelectorAll(`[${CLASS_ATTRIBUTE_NAME}]`) || []
+    const toMount = Array.from(document.querySelectorAll(`[${CLASS_ATTRIBUTE_NAME}]`))
 
     toMount.forEach((node) => {
       const className = node.getAttribute(CLASS_ATTRIBUTE_NAME)
@@ -78,7 +78,7 @@ const WebpackerReact = {
   },
 
   unmountComponents() {
-    const mounted = document.querySelectorAll(`[${CLASS_ATTRIBUTE_NAME}]`) || []
+    const mounted = Array.from(document.querySelectorAll(`[${CLASS_ATTRIBUTE_NAME}]`))
     mounted.forEach(node => ReactDOM.unmountComponentAtNode(node))
   },
 

--- a/javascript/webpacker_react-npm-module/src/index.js
+++ b/javascript/webpacker_react-npm-module/src/index.js
@@ -46,9 +46,10 @@ const WebpackerReact = {
     const name = component.name || (options !== undefined && options.as)
 
     if (!name) {
-      throw "Could not determine component name. Probably it's a functional component. " +
+      console.error("Could not determine component name. Probably it's a functional component. " +
       "Please declare component name by passing an 'as' parameter: " +
-      "register(Component,  {as: 'Component'})"
+      "register(Component,  {as: 'Component'})")
+      return false
     }
 
     if (this.registeredComponents[name]) {

--- a/javascript/webpacker_react-npm-module/src/index.js
+++ b/javascript/webpacker_react-npm-module/src/index.js
@@ -47,13 +47,13 @@ const WebpackerReact = {
 
     if (!name) {
       console.error("Could not determine component name. Probably it's a functional component. " +
-      "Please declare component name by passing an 'as' parameter: " +
-      "register(Component,  {as: 'Component'})")
+          "Please declare component name by passing an 'as' parameter: " +
+          "register(Component,  {as: 'Component'})")
       return false
     }
 
     if (this.registeredComponents[name]) {
-      console.warn(`webpacker-react: Cant register component, another one with this name is already registered: ${name}`)
+      console.warn(`webpacker-react: Cant register component, another one with this name is already registered: ${name}, registered components are ${this.registeredComponents}`)
       return false
     }
 
@@ -61,11 +61,19 @@ const WebpackerReact = {
     return true
   },
 
+  unmountComponents() {
+    const mounted = document.querySelectorAll(`[${CLASS_ATTRIBUTE_NAME}]`)
+    for (let i = 0; i < mounted.length; i += 1) {
+      ReactDOM.unmountComponentAtNode(mounted[i])
+    }
+  },
+
   mountComponents() {
     const registeredComponents = this.registeredComponents
-    const toMount = Array.from(document.querySelectorAll(`[${CLASS_ATTRIBUTE_NAME}]`))
+    const toMount = document.querySelectorAll(`[${CLASS_ATTRIBUTE_NAME}]`)
 
-    toMount.forEach((node) => {
+    for (let i = 0; i < toMount.length; i += 1) {
+      const node = toMount[i]
       const className = node.getAttribute(CLASS_ATTRIBUTE_NAME)
       const component = registeredComponents[className]
 
@@ -74,12 +82,7 @@ const WebpackerReact = {
       } else {
         console.error(`webpacker-react: cant render a component that has not been registered: ${className}`)
       }
-    })
-  },
-
-  unmountComponents() {
-    const mounted = Array.from(document.querySelectorAll(`[${CLASS_ATTRIBUTE_NAME}]`))
-    mounted.forEach(node => ReactDOM.unmountComponentAtNode(node))
+    }
   },
 
   addEventEventhandlers() {

--- a/javascript/webpacker_react-npm-module/src/index.js
+++ b/javascript/webpacker_react-npm-module/src/index.js
@@ -11,14 +11,14 @@ const WebpackerReact = {
   wrapForHMR: null,
 
   render: function (node, component) {
-    var propsJson = node.getAttribute(PROPS_ATTRIBUTE_NAME)
-    var props = propsJson && JSON.parse(propsJson)
+      var propsJson = node.getAttribute(PROPS_ATTRIBUTE_NAME)
+      var props = propsJson && JSON.parse(propsJson)
 
-    let reactElement = React.createElement(component, props)
-    if (this.wrapForHMR) {
-      reactElement = this.wrapForHMR(reactElement)
-    }
-    ReactDOM.render(reactElement, node)
+      let reactElement = React.createElement(component, props)
+      if (this.wrapForHMR) {
+        reactElement = this.wrapForHMR(reactElement)
+      }
+      ReactDOM.render(reactElement, node)
   },
 
   renderOnHMR(component) {
@@ -63,6 +63,8 @@ const WebpackerReact = {
   },
 
   mountComponents() {
+    console.debug("Mounting components")
+
     var registeredComponents = this.registeredComponents
     var toMount = document.querySelectorAll('[' + CLASS_ATTRIBUTE_NAME + ']')
 
@@ -80,10 +82,13 @@ const WebpackerReact = {
   },
 
   unmountComponents() {
+    console.debug("Unmounting components")
+
     var mounted = document.querySelectorAll('[' + CLASS_ATTRIBUTE_NAME + ']')
 
     for (var i = 0; i < mounted.length; ++i) {
       var node = mounted[i];
+      console.log(node);
       ReactDOM.unmountComponentAtNode(node);
     }
   },

--- a/javascript/webpacker_react-npm-module/src/ujs.js
+++ b/javascript/webpacker_react-npm-module/src/ujs.js
@@ -1,12 +1,16 @@
 const ujs = {
-  handleEvent: function(eventName, callback) {
+  handleEvent: function (eventName, callback, {once} = {once: false}) {
     // jQuery is optional. Use it to support legacy browsers.
     var $ = (typeof window.jQuery !== 'undefined') && window.jQuery;
 
     if ($) {
-      $(document).on(eventName, callback);
+      if (once) {
+        $(document).one(eventName, callback);
+      } else {
+        $(document).on(eventName, callback);
+      }
     } else {
-      document.addEventListener(eventName, callback);
+      document.addEventListener(eventName, callback, {once});
     }
   },
 
@@ -32,7 +36,8 @@ const ujs = {
   },
 
   turbolinks5: function (onMount, onUnmount) {
-    this.handleEvent('turbolinks:load', onMount);
+    this.handleEvent('turbolinks:load', onMount, {once: true});
+    this.handleEvent('turbolinks:render', onMount);
     this.handleEvent('turbolinks:before-render', onUnmount);
   },
 

--- a/javascript/webpacker_react-npm-module/src/ujs.js
+++ b/javascript/webpacker_react-npm-module/src/ujs.js
@@ -1,0 +1,80 @@
+const ujs = {
+  handleEvent: function(eventName, callback) {
+    // jQuery is optional. Use it to support legacy browsers.
+    var $ = (typeof window.jQuery !== 'undefined') && window.jQuery;
+
+    if ($) {
+      $(document).on(eventName, callback);
+    } else {
+      document.addEventListener(eventName, callback);
+    }
+  },
+
+  setup: function (onMount, onUnmount) {
+    var $ = (typeof window.jQuery !== 'undefined') && window.jQuery;
+    // Detect which kind of events to set up:
+    if (typeof Turbolinks !== 'undefined' && Turbolinks.supported) {
+      if (typeof Turbolinks.EVENTS !== 'undefined') {
+        // Turbolinks.EVENTS is in classic version 2.4.0+
+        this.turbolinksClassic(onMount, onUnmount);
+      } else if (typeof Turbolinks.controller !== "undefined") {
+        // Turbolinks.controller is in version 5+
+        this.turbolinks5(onMount, onUnmount);
+      } else {
+        // ReactRailsUJS.TurbolinksClassicDeprecated.setup();
+        this.turbolinksClassicDeprecated(onMount, onUnmount);
+      }
+    } else if ($ && typeof $.pjax === 'function') {
+      this.pjax(onMount, onUnmount);
+    } else {
+      this.native(onMount);
+    }
+  },
+
+  turbolinks5: function (onMount, onUnmount) {
+    this.handleEvent('turbolinks:load', onMount);
+    this.handleEvent('turbolinks:before-render', onUnmount);
+  },
+
+  turbolinksClassic: function (onMount, onUnmount) {
+    this.handleEvent(Turbolinks.EVENTS.CHANGE, onMount);
+    this.handleEvent(Turbolinks.EVENTS.BEFORE_UNLOAD, onUnmount);
+  },
+
+  turbolinksClassicDeprecated: function (onMount, onUnmount) {
+    // Before Turbolinks 2.4.0, Turbolinks didn't
+    // have named events and didn't have a before-unload event.
+    // Also, it didn't work with the Turbolinks cache, see
+    // https://github.com/reactjs/react-rails/issues/87
+    Turbolinks.pagesCached(0);
+    this.handleEvent('page:change', onMount);
+    this.handleEvent('page:receive', onUnmount);
+  },
+
+  pjax: function (onMount, onUnmount) {
+    this.handleEvent('ready', onMount);
+    this.handleEvent('pjax:end', onMount);
+    this.handleEvent('pjax:beforeReplace', onUnmount);
+  },
+
+  native: function (onMount) {
+    var $ = (typeof window.jQuery !== 'undefined') && window.jQuery;
+
+    if ($) {
+      $(function () {
+        onMount()
+      });
+    } else if ('addEventListener' in window) {
+      document.addEventListener('DOMContentLoaded', function () {
+        onMount()
+      });
+    } else {
+      // add support to IE8 without jQuery
+      window.attachEvent('onload', function () {
+        onMount()
+      });
+    }
+  }
+}
+
+export default ujs;

--- a/javascript/webpacker_react-npm-module/src/ujs.js
+++ b/javascript/webpacker_react-npm-module/src/ujs.js
@@ -1,9 +1,7 @@
-const $ = (typeof window.jQuery !== 'undefined') && window.jQuery
-const Turbolinks = window.Turbolinks
-
 const ujs = {
-
   handleEvent(eventName, callback, { once } = { once: false }) {
+    const $ = (typeof window.jQuery !== 'undefined') && window.jQuery
+
     if ($) {
       if (once) {
         $(document).one(eventName, callback)
@@ -16,6 +14,9 @@ const ujs = {
   },
 
   setup(onMount, onUnmount) {
+    const $ = (typeof window.jQuery !== 'undefined') && window.jQuery
+    const Turbolinks = window.Turbolinks
+
     // Detect which kind of events to set up:
     if (typeof Turbolinks !== 'undefined' && Turbolinks.supported) {
       if (typeof Turbolinks.EVENTS !== 'undefined') {
@@ -41,6 +42,8 @@ const ujs = {
   },
 
   turbolinksClassic(onMount, onUnmount) {
+    const Turbolinks = window.Turbolinks
+
     this.handleEvent(Turbolinks.EVENTS.CHANGE, onMount)
     this.handleEvent(Turbolinks.EVENTS.BEFORE_UNLOAD, onUnmount)
   },
@@ -50,6 +53,7 @@ const ujs = {
     // have named events and didn't have a before-unload event.
     // Also, it didn't work with the Turbolinks cache, see
     // https://github.com/reactjs/react-rails/issues/87
+    const Turbolinks = window.Turbolinks
     Turbolinks.pagesCached(0)
     this.handleEvent('page:change', onMount)
     this.handleEvent('page:receive', onUnmount)
@@ -62,6 +66,7 @@ const ujs = {
   },
 
   native(onMount) {
+    const $ = (typeof window.jQuery !== 'undefined') && window.jQuery
     if ($) {
       $(() => onMount())
     } else if ('addEventListener' in window) {

--- a/javascript/webpacker_react-npm-module/src/ujs.js
+++ b/javascript/webpacker_react-npm-module/src/ujs.js
@@ -1,3 +1,7 @@
+// This module is an adapted version from rails-ujs module
+// implemented in http://github.com/reactjs/react-rails
+// which is distributed under Apache License 2.0
+
 const ujs = {
   handleEvent(eventName, callback, { once } = { once: false }) {
     const $ = (typeof window.jQuery !== 'undefined') && window.jQuery

--- a/javascript/webpacker_react-npm-module/src/ujs.js
+++ b/javascript/webpacker_react-npm-module/src/ujs.js
@@ -1,85 +1,76 @@
-const ujs = {
-  handleEvent: function (eventName, callback, {once} = {once: false}) {
-    // jQuery is optional. Use it to support legacy browsers.
-    var $ = (typeof window.jQuery !== 'undefined') && window.jQuery;
+const $ = (typeof window.jQuery !== 'undefined') && window.jQuery
+const Turbolinks = window.Turbolinks
 
+const ujs = {
+
+  handleEvent(eventName, callback, { once } = { once: false }) {
     if ($) {
       if (once) {
-        $(document).one(eventName, callback);
+        $(document).one(eventName, callback)
       } else {
-        $(document).on(eventName, callback);
+        $(document).on(eventName, callback)
       }
     } else {
-      document.addEventListener(eventName, callback, {once});
+      document.addEventListener(eventName, callback, { once })
     }
   },
 
-  setup: function (onMount, onUnmount) {
-    var $ = (typeof window.jQuery !== 'undefined') && window.jQuery;
+  setup(onMount, onUnmount) {
     // Detect which kind of events to set up:
     if (typeof Turbolinks !== 'undefined' && Turbolinks.supported) {
       if (typeof Turbolinks.EVENTS !== 'undefined') {
         // Turbolinks.EVENTS is in classic version 2.4.0+
-        this.turbolinksClassic(onMount, onUnmount);
-      } else if (typeof Turbolinks.controller !== "undefined") {
+        this.turbolinksClassic(onMount, onUnmount)
+      } else if (typeof Turbolinks.controller !== 'undefined') {
         // Turbolinks.controller is in version 5+
-        this.turbolinks5(onMount, onUnmount);
+        this.turbolinks5(onMount, onUnmount)
       } else {
-        // ReactRailsUJS.TurbolinksClassicDeprecated.setup();
-        this.turbolinksClassicDeprecated(onMount, onUnmount);
+        this.turbolinksClassicDeprecated(onMount, onUnmount)
       }
     } else if ($ && typeof $.pjax === 'function') {
-      this.pjax(onMount, onUnmount);
+      this.pjax(onMount, onUnmount)
     } else {
-      this.native(onMount);
+      this.native(onMount)
     }
   },
 
-  turbolinks5: function (onMount, onUnmount) {
-    this.handleEvent('turbolinks:load', onMount, {once: true});
-    this.handleEvent('turbolinks:render', onMount);
-    this.handleEvent('turbolinks:before-render', onUnmount);
+  turbolinks5(onMount, onUnmount) {
+    this.handleEvent('turbolinks:load', onMount, { once: true })
+    this.handleEvent('turbolinks:render', onMount)
+    this.handleEvent('turbolinks:before-render', onUnmount)
   },
 
-  turbolinksClassic: function (onMount, onUnmount) {
-    this.handleEvent(Turbolinks.EVENTS.CHANGE, onMount);
-    this.handleEvent(Turbolinks.EVENTS.BEFORE_UNLOAD, onUnmount);
+  turbolinksClassic(onMount, onUnmount) {
+    this.handleEvent(Turbolinks.EVENTS.CHANGE, onMount)
+    this.handleEvent(Turbolinks.EVENTS.BEFORE_UNLOAD, onUnmount)
   },
 
-  turbolinksClassicDeprecated: function (onMount, onUnmount) {
+  turbolinksClassicDeprecated(onMount, onUnmount) {
     // Before Turbolinks 2.4.0, Turbolinks didn't
     // have named events and didn't have a before-unload event.
     // Also, it didn't work with the Turbolinks cache, see
     // https://github.com/reactjs/react-rails/issues/87
-    Turbolinks.pagesCached(0);
-    this.handleEvent('page:change', onMount);
-    this.handleEvent('page:receive', onUnmount);
+    Turbolinks.pagesCached(0)
+    this.handleEvent('page:change', onMount)
+    this.handleEvent('page:receive', onUnmount)
   },
 
-  pjax: function (onMount, onUnmount) {
-    this.handleEvent('ready', onMount);
-    this.handleEvent('pjax:end', onMount);
-    this.handleEvent('pjax:beforeReplace', onUnmount);
+  pjax(onMount, onUnmount) {
+    this.handleEvent('ready', onMount)
+    this.handleEvent('pjax:end', onMount)
+    this.handleEvent('pjax:beforeReplace', onUnmount)
   },
 
-  native: function (onMount) {
-    var $ = (typeof window.jQuery !== 'undefined') && window.jQuery;
-
+  native(onMount) {
     if ($) {
-      $(function () {
-        onMount()
-      });
+      $(() => onMount())
     } else if ('addEventListener' in window) {
-      document.addEventListener('DOMContentLoaded', function () {
-        onMount()
-      });
+      document.addEventListener('DOMContentLoaded', onMount)
     } else {
       // add support to IE8 without jQuery
-      window.attachEvent('onload', function () {
-        onMount()
-      });
+      window.attachEvent('onload', onMount)
     }
   }
 }
 
-export default ujs;
+export default ujs

--- a/javascript/webpacker_react-npm-module/yarn.lock
+++ b/javascript/webpacker_react-npm-module/yarn.lock
@@ -482,7 +482,7 @@ babel-polyfill@^6.23.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-preset-es2015@^6.18.0:
+babel-preset-es2015@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-preset-es2015/-/babel-preset-es2015-6.22.0.tgz#af5a98ecb35eb8af764ad8a5a05eb36dc4386835"
   dependencies:

--- a/test/example_app/app/controllers/pages_controller.rb
+++ b/test/example_app/app/controllers/pages_controller.rb
@@ -3,6 +3,7 @@ class PagesController < ApplicationController
   end
 
   def view_consecutive
+    @count = (params[:count] || 2).to_i
   end
 
   def controller_component

--- a/test/example_app/app/controllers/turbolinks_pages_controller.rb
+++ b/test/example_app/app/controllers/turbolinks_pages_controller.rb
@@ -1,0 +1,3 @@
+class TurbolinksPagesController < PagesController
+  layout 'turbolinks'
+end

--- a/test/example_app/app/javascript/packs/hello_react.js
+++ b/test/example_app/app/javascript/packs/hello_react.js
@@ -1,4 +1,4 @@
 import Hello from 'components/hello';
 import WebpackerReact from 'webpacker-react';
 
-WebpackerReact.register(Hello);
+WebpackerReact.register(Hello)

--- a/test/example_app/app/javascript/packs/hello_react.js
+++ b/test/example_app/app/javascript/packs/hello_react.js
@@ -1,4 +1,5 @@
 import Hello from 'components/hello';
 import WebpackerReact from 'webpacker-react';
 
-WebpackerReact.register(Hello)
+WebpackerReact.register(Hello);
+WebpackerReact.initialize();

--- a/test/example_app/app/javascript/packs/turbolinks_hello_react.js
+++ b/test/example_app/app/javascript/packs/turbolinks_hello_react.js
@@ -1,0 +1,12 @@
+import Hello from 'components/hello';
+import WebpackerReact from 'webpacker-react';
+import Turbolinks from 'turbolinks';
+
+Turbolinks.start()
+
+if (!window.Turbolinks) {
+  console.error("Turbolinks failed to install")
+}
+
+WebpackerReact.register(Hello)
+WebpackerReact.initialize()

--- a/test/example_app/app/views/layouts/turbolinks.html.erb
+++ b/test/example_app/app/views/layouts/turbolinks.html.erb
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>WebpackerReactExample</title>
+    <%= csrf_meta_tags %>
+
+    <%= javascript_pack_tag 'turbolinks_hello_react' %>
+  </head>
+
+  <body>
+    <%= yield %>
+  </body>
+</html>

--- a/test/example_app/app/views/pages/view_consecutive.html.erb
+++ b/test/example_app/app/views/pages/view_consecutive.html.erb
@@ -1,2 +1,6 @@
-<%= react_component('Hello', name: 'component 1') %>
-<%= react_component('Hello', name: 'component 2') %>
+<% @count.times do |i| %>
+  <%= react_component('Hello', name: "component #{i+1}") %>
+<% end %>
+
+<%= link_to "Show 2", count: 2 %>
+<%= link_to "Show 3", count: 3 %>

--- a/test/example_app/config/routes.rb
+++ b/test/example_app/config/routes.rb
@@ -3,5 +3,9 @@ Rails.application.routes.draw do
   get "/view_consecutive", to: "pages#view_consecutive"
   get "/controller", to: "pages#controller_component"
 
+  get "/turbolinks/view", to: "turbolinks_pages#view_component"
+  get "/turbolinks/view_consecutive", to: "turbolinks_pages#view_consecutive"
+  get "/turbolinks/controller", to: "turbolinks_pages#controller_component"
+
   root to: "pages#view_component"
 end

--- a/test/example_app/vendor/package.json
+++ b/test/example_app/vendor/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "dependencies": {
     "react": "^15.4.2",
-    "react-dom": "^15.4.2"
+    "react-dom": "^15.4.2",
+    "turbolinks": "^5.0.0"
   },
   "devDependencies": {
     "babel-core": "^6.22.1",

--- a/test/example_app/vendor/package.json
+++ b/test/example_app/vendor/package.json
@@ -8,6 +8,7 @@
   "devDependencies": {
     "babel-core": "^6.22.1",
     "babel-loader": "^6.2.10",
+    "babel-preset-es2015": "^6.22.0",
     "babel-preset-latest": "^6.22.0",
     "babel-preset-react": "^6.22.0",
     "coffee-loader": "^0.7.2",

--- a/test/example_app/vendor/package.json
+++ b/test/example_app/vendor/package.json
@@ -9,7 +9,6 @@
   "devDependencies": {
     "babel-core": "^6.22.1",
     "babel-loader": "^6.2.10",
-    "babel-preset-es2015": "^6.22.0",
     "babel-preset-latest": "^6.22.0",
     "babel-preset-react": "^6.22.0",
     "coffee-loader": "^0.7.2",

--- a/test/example_app/vendor/yarn.lock
+++ b/test/example_app/vendor/yarn.lock
@@ -2767,6 +2767,10 @@ tunnel-agent@~0.4.1:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.4.3.tgz#6373db76909fe570e08d73583365ed828a74eeeb"
 
+turbolinks@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/turbolinks/-/turbolinks-5.0.0.tgz#94c73fa299716824b0d96639b993b2efd7ef0e44"
+
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"

--- a/test/integration/renderer_test.rb
+++ b/test/integration/renderer_test.rb
@@ -1,27 +1,31 @@
 require "test_helper"
 
 class RendererTest < ActionDispatch::IntegrationTest
+  def url_prefix
+    ""
+  end
+
   test "renders from a view" do
-    get "/view"
+    get url_prefix + "/view"
     assert_select "div[data-react-class]", true
   end
 
   test "renders from a controller" do
-    get "/controller"
+    get url_prefix + "/controller"
     assert_select "div[data-react-class]", true
   end
 
   test "component mounts" do
     require_js
 
-    visit "/view"
+    visit url_prefix + "/view"
     assert page.has_content? "Hello, I am a component rendered from a view!"
   end
 
   test "consecutive components mounts" do
     require_js
 
-    visit "/view_consecutive"
+    visit url_prefix + "/view_consecutive"
 
     assert page.has_content? "component 1"
     assert page.has_content? "component 2"

--- a/test/integration/renderer_with_turbolinks_test.rb
+++ b/test/integration/renderer_with_turbolinks_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+require_relative "./renderer_test"
+
+class RendererWithTurbolinksTest < RendererTest
+  def url_prefix
+    "/turbolinks"
+  end
+
+  test "Turbolinks visits" do
+    require_js
+
+    visit url_prefix + "/view_consecutive"
+
+    assert page.has_content? "component 1"
+    assert page.has_content? "component 2"
+
+    click_link "Show 3"
+
+    assert page.has_content? "component 3"
+
+    click_link "Show 2"
+
+    assert page.has_content? "component 1"
+    assert page.has_content? "component 2"
+    assert page.has_no_content? "component 3"
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,7 @@ require "capybara/rails"
 class ActionDispatch::IntegrationTest
   include Capybara::DSL
   require "capybara/poltergeist"
+
   Capybara.javascript_driver = :poltergeist
 
   def teardown


### PR DESCRIPTION
React components will be mounted and unmounted on events specific for:

* Turbolinks 5
* Turbolinks 2.4+
* old, deprecated Turbolinks
* PJAX
* without any partial page loading technology present

This code is copied with modifications from https://github.com/reactjs/react-rails with modifications.

This resolves #13 