### PR TITLE
Remove component name detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## 0.2.0 - in progress
 ### Added
 - support for Turbolinks5, Turbolinks 2.4 and PJAX. Components will be mounted and unmounted when Turbolinks-specific events occur. Also, the integration works with Turbolinks 5 cache.
-- Now, Webpacker::React *always* requires an explicit initialization via `WebpackerReact.initialize()`, which must be done after the Turbolinks initialization, if the Turbolinks library is used.
+- New `WebpackerReact.setup({Component1, Component2, ...})` initialization API. The old API couldn't properly detect the components' names, thus user is required to provide the names in the configuration object's keys. 
+### Removed
+- `WebpackerReact.register(Component)` has been dropped in favor of `WebpackerReact.setup({Component})`
 ## 0.1.0 - 2017-02-23
 ### Added
 - First released version

--- a/README.md
+++ b/README.md
@@ -50,12 +50,8 @@ In your pack file (`app/javascript/packs/*.js`), import your components as well 
 import Hello from 'components/hello'
 import WebpackerReact from 'webpacker-react'
 
-<<<<<<< HEAD
-WebpackerReact.register(Hello)
 WebpackerReact.initialize()
-=======
 WebpackerReact.register({Hello})
->>>>>>> Remove automatic name detection, allow passing many components to WebpackerReact.register
 ```
 
 ### With Turbolinks

--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ In your pack file (`app/javascript/packs/*.js`), import your components as well 
 import Hello from 'components/hello'
 import WebpackerReact from 'webpacker-react'
 
-WebpackerReact.initialize()
-WebpackerReact.register({Hello})
+WebpackerReact.setup({Hello})
 ```
 
 ### With Turbolinks
@@ -66,9 +65,8 @@ import WebpackerReact from 'webpacker-react'
 import Turbolinks from 'turbolinks'
 
 Turbolinks.start()
-WebpackerReact.initialize()
 
-WebpackerReact.register({Hello})
+WebpackerReact.setup({Hello})
 ```
 
 You may also load turbolinks in regular asset pipeline `application.js`:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ import Turbolinks from 'turbolinks'
 Turbolinks.start()
 WebpackerReact.initialize()
 
-WebpackerReact.register(Hello)
+WebpackerReact.register({Hello})
 ```
 
 You may also load turbolinks in regular asset pipeline `application.js`:

--- a/README.md
+++ b/README.md
@@ -50,8 +50,12 @@ In your pack file (`app/javascript/packs/*.js`), import your components as well 
 import Hello from 'components/hello'
 import WebpackerReact from 'webpacker-react'
 
+<<<<<<< HEAD
 WebpackerReact.register(Hello)
 WebpackerReact.initialize()
+=======
+WebpackerReact.register({Hello})
+>>>>>>> Remove automatic name detection, allow passing many components to WebpackerReact.register
 ```
 
 ### With Turbolinks

--- a/javascript/webpacker_react-npm-module/package.json
+++ b/javascript/webpacker_react-npm-module/package.json
@@ -13,5 +13,8 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-react": "^6.10.0"
+  },
+  "dependencies": {
+    "lodash": "^4.0.0"
   }
 }

--- a/javascript/webpacker_react-npm-module/src/index.js
+++ b/javascript/webpacker_react-npm-module/src/index.js
@@ -42,17 +42,6 @@ const WebpackerReact = {
     this.wrapForHMR = wrapForHMR
   },
 
-  register(component) {
-    console.warn('webpacker-react: WebpackerReact.register(component) has been deprecated, because it can not support functional components. It will be removed in future versions. Use WebpackerReact.setup({Component, ...}) instead.')
-
-    const name = component.name
-    if (name) {
-      this.setup({ [name]: component })
-    } else {
-      console.error('webpacker-react: WebpackerReact.register(component) does not support functional components. Use WebpackerReact.setup({Component, ...}) instead')
-    }
-  },
-
   registerComponents(components) {
     const collisions = intersection(keys(this.registeredComponents), keys(components))
     if (collisions.length > 0) {

--- a/javascript/webpacker_react-npm-module/src/index.js
+++ b/javascript/webpacker_react-npm-module/src/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import _ from 'lodash'
+import { intersection, keys, assign, omit } from 'lodash'
 import ujs from './ujs'
 
 const CLASS_ATTRIBUTE_NAME = 'data-react-class'
@@ -54,12 +54,12 @@ const WebpackerReact = {
   },
 
   registerComponents(components) {
-    const collisions = _.intersection(_.keys(this.registeredComponents), _.keys(components))
+    const collisions = intersection(keys(this.registeredComponents), keys(components))
     if (collisions.length > 0) {
       console.error(`webpacker-react: can not register components. Following components are already registered: ${collisions}`)
     }
 
-    _.assign(this.registeredComponents, _.omit(components, collisions))
+    assign(this.registeredComponents, omit(components, collisions))
     return true
   },
 

--- a/javascript/webpacker_react-npm-module/src/index.js
+++ b/javascript/webpacker_react-npm-module/src/index.js
@@ -69,7 +69,7 @@ const WebpackerReact = {
       const component = registeredComponents[className]
 
       if (component) {
-        this.render(node, component)
+        if (node.innerHTML.length === 0) this.render(node, component)
       } else {
         console.error(`webpacker-react: cant render a component that has not been registered: ${className}`)
       }
@@ -77,10 +77,13 @@ const WebpackerReact = {
   },
 
   setup(components = {}) {
-    this.registerComponents(components)
-    if (typeof window.WebpackerReact !== 'undefined') return
-    window.WebpackerReact = this
-    ujs.setup(this.mountComponents.bind(this), this.unmountComponents.bind(this))
+    if (typeof window.WebpackerReact === 'undefined') {
+      window.WebpackerReact = this
+      ujs.setup(this.mountComponents.bind(this), this.unmountComponents.bind(this))
+    }
+
+    window.WebpackerReact.registerComponents(components)
+    window.WebpackerReact.mountComponents()
   }
 }
 

--- a/javascript/webpacker_react-npm-module/src/index.js
+++ b/javascript/webpacker_react-npm-module/src/index.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
+import _ from 'lodash'
 import ujs from './ujs'
 
 const CLASS_ATTRIBUTE_NAME = 'data-react-class'
@@ -42,22 +43,13 @@ const WebpackerReact = {
     this.wrapForHMR = wrapForHMR
   },
 
-  register(component) {
-    const name = component.name
-
-    if (!name) {
-      console.error("Could not determine component name. Probably it's a functional component. " +
-          "Please declare component name by passing an 'as' parameter: " +
-          "register(Component,  {as: 'Component'})")
+  register(components) {
+    const collisions = _.intersection(_.keys(this.registeredComponents), _.keys(components))
+    if (collisions.length > 0) {
+      console.warn(`webpack-react: can not register components. Following components are already registered: ${collisions}`)
       return false
     }
-
-    if (this.registeredComponents[name]) {
-      console.warn(`webpacker-react: Cant register component, another one with this name is already registered: ${name}, registered components are ${this.registeredComponents}`)
-      return false
-    }
-
-    this.registeredComponents[name] = component
+    _.assign(this.registeredComponents, components)
     return true
   },
 

--- a/javascript/webpacker_react-npm-module/yarn.lock
+++ b/javascript/webpacker_react-npm-module/yarn.lock
@@ -564,8 +564,8 @@ babel-types@^6.19.0, babel-types@^6.22.0, babel-types@^6.23.0:
     to-fast-properties "^1.0.1"
 
 babylon@^6.11.0, babylon@^6.15.0:
-  version "6.15.0"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.15.0.tgz#ba65cfa1a80e1759b0e89fb562e27dccae70348e"
+  version "6.16.1"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.16.1.tgz#30c5a22f481978a9e7f8cdfdf496b11d94b404d3"
 
 balanced-match@^0.4.1:
   version "0.4.2"
@@ -1573,7 +1573,7 @@ lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
-lodash@^4.0.0, lodash@^4.2.0, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.2.0, lodash@^4.3.0, "lodash@~> 4":
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -1860,8 +1860,8 @@ rc@~1.1.6:
     strip-json-comments "~2.0.1"
 
 "readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.0.2, readable-stream@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.2.tgz#a9e6fec3c7dda85f8bb1b3ba7028604556fc825e"
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.3.tgz#9cf49463985df016c8ae8813097a9293a9b33729"
   dependencies:
     buffer-shims "^1.0.0"
     core-util-is "~1.0.0"
@@ -2010,7 +2010,13 @@ restore-cursor@^1.0.1:
     exit-hook "^1.0.0"
     onetime "^1.0.0"
 
-rimraf@2, rimraf@^2.2.8, rimraf@~2.5.1, rimraf@~2.5.4:
+rimraf@2, rimraf@^2.2.8:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
+  dependencies:
+    glob "^7.0.5"
+
+rimraf@~2.5.1, rimraf@~2.5.4:
   version "2.5.4"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.5.4.tgz#96800093cbf1a0c86bd95b4625467535c29dfa04"
   dependencies:

--- a/test/example_app/app/controllers/pages_controller.rb
+++ b/test/example_app/app/controllers/pages_controller.rb
@@ -7,6 +7,6 @@ class PagesController < ApplicationController
   end
 
   def controller_component
-    render react_component: "Hello", props: { name: "a component rendered from a controller" }
+    render react_component: "HelloReact", props: { name: "a component rendered from a controller" }
   end
 end

--- a/test/example_app/app/controllers/two_packs_controller.rb
+++ b/test/example_app/app/controllers/two_packs_controller.rb
@@ -1,0 +1,6 @@
+class TwoPacksController < ApplicationController
+  layout 'two_packs'
+
+  def view_all
+  end
+end

--- a/test/example_app/app/javascript/packs/a.js
+++ b/test/example_app/app/javascript/packs/a.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import WebpackerReact from 'webpacker-react';
+import HelloReact from 'components/hello';
+
+const A = (props) => <div>Component A</div>;
+
+WebpackerReact.setup({A, HelloReact});

--- a/test/example_app/app/javascript/packs/b.js
+++ b/test/example_app/app/javascript/packs/b.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import WebpackerReact from 'webpacker-react';
+
+const HelloReact = (props) => <div>This component will be ignored</div>;
+const B = (props) => <div>Component B</div>;
+
+WebpackerReact.setup({HelloReact, B});

--- a/test/example_app/app/javascript/packs/hello_react.js
+++ b/test/example_app/app/javascript/packs/hello_react.js
@@ -1,5 +1,5 @@
-import Hello from 'components/hello';
+import HelloReact from 'components/hello';
 import WebpackerReact from 'webpacker-react';
 
-WebpackerReact.register(Hello);
-WebpackerReact.initialize();
+WebpackerReact.initialize()
+WebpackerReact.register({HelloReact})

--- a/test/example_app/app/javascript/packs/turbolinks_hello_react.js
+++ b/test/example_app/app/javascript/packs/turbolinks_hello_react.js
@@ -1,4 +1,4 @@
-import Hello from 'components/hello';
+import HelloReact from 'components/hello';
 import WebpackerReact from 'webpacker-react';
 import Turbolinks from 'turbolinks';
 
@@ -8,5 +8,5 @@ if (!window.Turbolinks) {
   console.error("Turbolinks failed to install")
 }
 
-WebpackerReact.register(Hello)
+WebpackerReact.register({HelloReact})
 WebpackerReact.initialize()

--- a/test/example_app/app/views/layouts/two_packs.html.erb
+++ b/test/example_app/app/views/layouts/two_packs.html.erb
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>WebpackerReactExample</title>
+    <%= csrf_meta_tags %>
+
+    <%= javascript_pack_tag 'a' %>
+    <%= javascript_pack_tag 'b' %>
+  </head>
+
+  <body>
+    <%= yield %>
+  </body>
+</html>

--- a/test/example_app/app/views/pages/view_component.html.erb
+++ b/test/example_app/app/views/pages/view_component.html.erb
@@ -1,1 +1,1 @@
-<%= react_component('Hello', name: 'a component rendered from a view') %>
+<%= react_component('HelloReact', name: 'a component rendered from a view') %>

--- a/test/example_app/app/views/pages/view_consecutive.html.erb
+++ b/test/example_app/app/views/pages/view_consecutive.html.erb
@@ -1,5 +1,5 @@
 <% @count.times do |i| %>
-  <%= react_component('Hello', name: "component #{i+1}") %>
+  <%= react_component('HelloReact', name: "component #{i+1}") %>
 <% end %>
 
 <%= link_to "Show 2", count: 2 %>

--- a/test/example_app/app/views/two_packs/view_all.html.erb
+++ b/test/example_app/app/views/two_packs/view_all.html.erb
@@ -1,0 +1,3 @@
+<%= react_component('HelloReact', name: 'a component rendered from a view') %>
+<%= react_component('A') %>
+<%= react_component('B') %>

--- a/test/example_app/config/routes.rb
+++ b/test/example_app/config/routes.rb
@@ -7,5 +7,7 @@ Rails.application.routes.draw do
   get "/turbolinks/view_consecutive", to: "turbolinks_pages#view_consecutive"
   get "/turbolinks/controller", to: "turbolinks_pages#controller_component"
 
+  get "/two_packs/view_all", to: "two_packs#view_all"
+
   root to: "pages#view_component"
 end

--- a/test/integration/renderer_with_two_packs_test.rb
+++ b/test/integration/renderer_with_two_packs_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+require "irb"
+
+class RendererWithTwoPacksTest < ActionDispatch::IntegrationTest
+
+  test "component mounts" do
+    require_js
+
+    begin
+      visit "/two_packs/view_all"
+    rescue Capybara::Poltergeist::JavascriptError => error
+      assert error.message =~ /Following components are already registered: HelloReact/
+    end
+
+    assert page.has_content? "Hello, I am a component rendered from a view!"
+    assert page.has_content? "Component A"
+    assert page.has_content? "Component B"
+  end
+
+  private
+
+  def require_js
+    Capybara.current_driver = Capybara.javascript_driver
+  end
+end


### PR DESCRIPTION
Please revie #14 first.

Remove automatic name detection, allow passing many components to WebpackerReact.register

Name detection did not work for functional components. Passing an object with component names as keys and components as values allows to leverage ES6 shorthand for objects (see changes in the README.md).

Please look at the second commit to see changes. I based changes here on my previous pull request (sorry for that - I can clean this up later).