### PR TITLE
Simplify installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,20 +22,16 @@ Your Rails application needs to use Webpacker and have the React integration don
 First, you need to add the webpacker-react gem to your Rails app Gemfile:
 
 ```ruby
-gem 'webpacker-react', "~>0.1.0"
+gem 'webpacker-react', "~> 0.1.0"
 ```
 
-Once done, run `bundler` to install the gem.
+Once done, run `bundle` to install the gem.
 
-Then you need to update your `vendor/package.json` file to include the `webpacker-react` NPM module:
-```json
-  "dependencies": {
-    "..."
-    "webpacker-react": "~>0.1.0"
-  },
-```
+Then you need to update your `package.json` file to include the `webpacker-react` NPM module:
 
-Finally, run `./bin/yarn` to install the module. You are now all set!
+`./bin/yarn add webpacker-react@0.1.x`
+
+You are now all set!
 
 ### Note about versions
 


### PR DESCRIPTION
Changes:
* [webpacker has moved](https://github.com/rails/webpacker/pull/101) `package.json` (and related files) to the project root from `vendor/`
* There is no need to edit `package.json` directly. I added a `yarn` command to take care of adding the `webpacker-react` module & install it.

Fixes #11
