### PR TITLE
Proper caching and mounting with Turbolinks 5

### DIFF
--- a/javascript/webpacker_react-npm-module/src/index.js
+++ b/javascript/webpacker_react-npm-module/src/index.js
@@ -69,7 +69,7 @@ const WebpackerReact = {
       const component = registeredComponents[className]
 
       if (component) {
-        if (node.innerHTML.length === 0) this.render(node, component)
+        this.render(node, component)
       } else {
         console.error(`webpacker-react: cant render a component that has not been registered: ${className}`)
       }

--- a/javascript/webpacker_react-npm-module/src/ujs.js
+++ b/javascript/webpacker_react-npm-module/src/ujs.js
@@ -40,8 +40,7 @@ const ujs = {
   },
 
   turbolinks5(onMount, onUnmount) {
-    this.handleEvent('turbolinks:load', onMount, { once: true })
-    this.handleEvent('turbolinks:render', onMount)
+    this.handleEvent('turbolinks:load', onMount)
     this.handleEvent('turbolinks:before-render', onUnmount)
   },
 


### PR DESCRIPTION
Fixes #27

Changes:

Follow the pattern of [react-rails](https://github.com/reactjs/react-rails/blob/master/lib/assets/javascripts/react_ujs_turbolinks.js) and always mount components on `turbolinks:load` whether initial HTML exists or not.


Please ensure that:
- [ ] Changelog is updated if not a minor patch
- [ ] Ruby linting is ok: `rubocop` is all green
- [ ] Javascript linting is ok: `cd javascript/webpacker_react-npm-module/ && yarn lint` is all green
- [ ] [Tests](https://github.com/renchap/webpacker-react#testing) are all green
