### PR TITLE
Fix grammar in warning when wrapForHMR is not set

### DIFF
--- a/javascript/webpacker_react-npm-module/src/index.js
+++ b/javascript/webpacker_react-npm-module/src/index.js
@@ -30,7 +30,7 @@ const WebpackerReact = {
     this.registeredComponents[name] = component
 
     if (!this.wrapForHMR) {
-      console.warn('webpacker-react: renderOnHMR called but not elements not wrapped for HMR')
+      console.warn('webpacker-react: renderOnHMR called but elements not wrapped for HMR')
     }
 
     const toMount = document.querySelectorAll(`[${CLASS_ATTRIBUTE_NAME}=${name}]`)


### PR DESCRIPTION
Fixes a minor grammatical issue in a warning message.

Changes:

Please ensure that:
- [x] Changelog is updated if not a minor patch
- [x] Ruby linting is ok: `rubocop` is all green
- [x] Javascript linting is ok: `cd javascript/webpacker_react-npm-module/ && yarn lint` is all green
- [x] [Tests](https://github.com/renchap/webpacker-react#testing) are all green
