### PR TITLE
Upgrade to react-hot-loader 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Instructions to set up `react-hot-loader` 4 (fixed #51)
+
+### Updated
+- Instructions for setting up `webpacker-react` with a modern Webpacker version
+
+### Removed
+- Support for `react-hot-loader`. Please look at the README for instructions on how to use `react-hot-loader` 4 with your app, it is much simpler and better!
+
 ## [0.3.2] - 2017-09-13
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    webpacker-react (0.3.2)
+    webpacker-react (0.4.0)
       webpacker
 
 GEM

--- a/javascript/webpacker_react-npm-module/dist/package.json
+++ b/javascript/webpacker_react-npm-module/dist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpacker-react",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Javascript",
   "main": "index.js",
   "homepage": "https://github.com/renchap/webpacker-react",
@@ -16,7 +16,6 @@
   "files": [
     "index.js",
     "configure-hot-module-replacement.js",
-    "hmr.js",
     "ujs.js"
   ],
   "scripts": {

--- a/javascript/webpacker_react-npm-module/src/configure-hot-module-replacement.js
+++ b/javascript/webpacker_react-npm-module/src/configure-hot-module-replacement.js
@@ -1,30 +1,13 @@
 import webpack from 'webpack'
 import merge from 'webpack-merge'
 
-function configureHotModuleReplacement(originalConfig) {
-  const config = merge(
-    originalConfig,
-    {
-      plugins: [
-        new webpack.NamedModulesPlugin()
-      ]
-    }
-  )
-
+function configureHotModuleReplacement(config) {
   config.module.rules = config.module.rules.map((rule) => {
     if (rule.loader === 'babel-loader') {
       return merge(rule, { options: { plugins: ['react-hot-loader/babel'] } })
     }
     return rule
   })
-
-  Object.keys(config.entry).forEach((key) => {
-    if (!(config.entry[key] instanceof Array)) {
-      config.entry[key] = [config.entry[key]]
-    }
-    config.entry[key].unshift('react-hot-loader/patch')
-  })
-  return config
 }
 
 module.exports = configureHotModuleReplacement

--- a/javascript/webpacker_react-npm-module/src/hmr.js
+++ b/javascript/webpacker_react-npm-module/src/hmr.js
@@ -1,9 +1,0 @@
-import { AppContainer } from 'react-hot-loader'
-import WebpackerReact from 'webpacker-react'
-import React from 'react'
-
-WebpackerReact.registerWrapForHMR(reactElement =>
-  React.createElement(AppContainer, {}, reactElement)
-)
-
-export default WebpackerReact

--- a/javascript/webpacker_react-npm-module/src/index.js
+++ b/javascript/webpacker_react-npm-module/src/index.js
@@ -11,38 +11,14 @@ const PROPS_ATTRIBUTE_NAME = 'data-react-props'
 
 const WebpackerReact = {
   registeredComponents: {},
-  wrapForHMR: null,
 
   render(node, component) {
     const propsJson = node.getAttribute(PROPS_ATTRIBUTE_NAME)
     const props = propsJson && JSON.parse(propsJson)
 
-    let reactElement = React.createElement(component, props)
-    if (this.wrapForHMR) {
-      reactElement = this.wrapForHMR(reactElement)
-    }
+    const reactElement = React.createElement(component, props)
+
     ReactDOM.render(reactElement, node)
-  },
-
-  renderOnHMR(component) {
-    const name = component.name
-
-    this.registeredComponents[name] = component
-
-    if (!this.wrapForHMR) {
-      console.warn('webpacker-react: renderOnHMR called but elements not wrapped for HMR')
-    }
-
-    const toMount = document.querySelectorAll(`[${CLASS_ATTRIBUTE_NAME}=${name}]`)
-    for (let i = 0; i < toMount.length; i += 1) {
-      const node = toMount[i]
-
-      this.render(node, component)
-    }
-  },
-
-  registerWrapForHMR(wrapForHMR) {
-    this.wrapForHMR = wrapForHMR
   },
 
   registerComponents(components) {

--- a/lib/webpacker/react/version.rb
+++ b/lib/webpacker/react/version.rb
@@ -1,5 +1,5 @@
 module Webpacker
   module React
-    VERSION = "0.3.2".freeze
+    VERSION = "0.4.0".freeze
   end
 end


### PR DESCRIPTION
`react-hot-loader` 4 is now released. This is a full rewrite with a lot of bug fixes.
More importantly, we no longer need to handle HMR in `webpacker-react`.

I removed HMR support and updated the README with the new HMR instructions.

I will merge this is a few days if nobody complains!