### PR TITLE
Remove contraction 'cant' in favor of 'can not'

### DIFF
--- a/javascript/webpacker_react-npm-module/src/index.js
+++ b/javascript/webpacker_react-npm-module/src/index.js
@@ -50,7 +50,7 @@ const WebpackerReact = {
       if (component) {
         if (node.innerHTML.length === 0) this.render(node, component)
       } else {
-        console.error(`webpacker-react: cant render a component that has not been registered: ${className}`)
+        console.error(`webpacker-react: can not render a component that has not been registered: ${className}`)
       }
     }
   },


### PR DESCRIPTION
The missing apostrophe bothered me, but I think this is better than
adding an apostrophe.

Please ensure that:
- [ ] Changelog is updated if not a minor patch
- [ ] Ruby linting is ok: `rubocop` is all green
- [ ] Javascript linting is ok: `cd javascript/webpacker_react-npm-module/ && yarn lint` is all green
- [ ] [Tests](https://github.com/renchap/webpacker-react#testing) are all green
