### PR TITLE
Let's use attr_accessor

### DIFF
--- a/lib/webpacker/react/component.rb
+++ b/lib/webpacker/react/component.rb
@@ -12,7 +12,7 @@ module Webpacker
 
       def render(props = {}, options = {})
         tag = options.delete(:tag) || :div
-        data = { data: { "react-class" => @name, "react-props" => props.to_json } }
+        data = { data: { "react-class" => name, "react-props" => props.to_json } }
 
         content_tag(tag, nil, options.deep_merge(data))
       end


### PR DESCRIPTION
Even though it's not a functional change, I find these small syntax fixing more readable

Fixes # .

Changes:

Please ensure that:
- [ ] Changelog is updated if not a minor patch
- [ ] Ruby linting is ok: `rubocop` is all green
- [ ] Javascript linting is ok: `cd javascript/webpacker_react-npm-module/ && yarn lint` is all green
- [ ] [Tests](https://github.com/renchap/webpacker-react#testing) are all green
