### PR TITLE
Update react syntax to v18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Tests now uses headless chrome instead of Poltergeist
 - Babel is configured with `babel-preset-env`
+- Updated React syntax to v18
 
 ### Removed
 - Support for `react-hot-loader`. Please look at the README for instructions on how to use `react-hot-loader` 4 with your app, it is much simpler and better!

--- a/javascript/webpacker_react-npm-module/src/index.js
+++ b/javascript/webpacker_react-npm-module/src/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import ReactDOM from 'react-dom'
+import { createRoot } from 'react-dom/client'
 import intersection from 'lodash/intersection'
 import keys from 'lodash/keys'
 import assign from 'lodash/assign'
@@ -17,8 +17,9 @@ const WebpackerReact = {
     const props = propsJson && JSON.parse(propsJson)
 
     const reactElement = React.createElement(component, props)
+    const root = createRoot(node)
 
-    ReactDOM.render(reactElement, node)
+    root.render(reactElement)
   },
 
   registerComponents(components) {
@@ -34,7 +35,7 @@ const WebpackerReact = {
   unmountComponents() {
     const mounted = document.querySelectorAll(`[${CLASS_ATTRIBUTE_NAME}]`)
     for (let i = 0; i < mounted.length; i += 1) {
-      ReactDOM.unmountComponentAtNode(mounted[i])
+      mounted[i].unmount()
     }
   },
 


### PR DESCRIPTION
Fixes # .
No issue

Changes:
Update React syntax to v18

Please ensure that:
- [x] Changelog is updated if not a minor patch
- [x] Ruby linting is ok: `rubocop` is all green
- [x] Javascript linting is ok: `cd javascript/webpacker_react-npm-module/ && yarn lint` is all green
- [x] [Tests](https://github.com/renchap/webpacker-react#testing) are all green
